### PR TITLE
Add custom model type

### DIFF
--- a/GREMWELL.md
+++ b/GREMWELL.md
@@ -1,0 +1,33 @@
+# GREMWELL Implementation Roadmap
+
+This document outlines the planned work for integrating a new **Gremwell** testing mode into `promptmap2`. The goal is to provide repeatable tests against a simple FastAPI application to evaluate prompt injection defenses.
+
+## Proposed Command Line Options
+
+The following options will be added to `promptmap2.py`:
+
+| Option | Default | Purpose |
+|-------|---------|---------|
+| `--target-url` | `http://localhost:8000` | Base URL of the FastAPI demo to test. |
+| `--gremwell-config` | `gremwell.yaml` | Path to additional configuration specific to the Gremwell mode. |
+| `--gremwell` | off | Enable Gremwell testing mode. When active, prompts are sent to the FastAPI target instead of a local system prompt file. |
+
+Existing parameters such as `--model`, `--model-type`, `--rules`, and `--iterations` will still apply.
+
+## Files to Modify
+
+- `promptmap2.py` – extend the argument parser to accept the new options and implement logic for issuing requests to the target URL when `--gremwell` is specified.
+- `requirements.txt` – include `fastapi` and `uvicorn` for the demo server.
+- `README.md` – document how to launch the FastAPI test server and how to use the new CLI arguments.
+- `tests/` (new directory) – host automated tests for the Gremwell mode.
+  - `tests/fastapi_app.py` – minimal FastAPI application that exposes a vulnerable `/chat` endpoint.
+  - `tests/test_gremwell.py` – integration tests invoking the CLI against the local FastAPI server.
+
+## Test Cases
+
+1. **Prompt Stealing** – send crafted prompts through the FastAPI endpoint and verify the system prompt is leaked.
+2. **Distraction** – ensure the LLM answers out-of-scope questions when distracted via the API.
+3. **Firewall Mode** – confirm that when the endpoint acts as a firewall, responses include the expected pass condition.
+
+The demo FastAPI application will intentionally echo received prompts to make testing straightforward. Tests will run the server using `uvicorn` in a background process and then call `promptmap2.py` with the new options.
+

--- a/README.md
+++ b/README.md
@@ -80,12 +80,17 @@ python promptmap2.py --model "llama2:7b" --model-type ollama
 # If the model is not installed, promptmap will ask you to download it. If you want to download it automatically, you can use `-y` flag.
 ```
 
-4. JSON output:
+4. Test with a custom model:
+```bash
+python promptmap2.py --model sshleifer/tiny-gpt2 --model-type custom
+```
+
+5. JSON output:
 ```bash
 python promptmap2.py --model gpt-4 --model-type openai --output results.json
 ```
 
-5. Custom number of test iterations:
+6. Custom number of test iterations:
 
 LLM applications may appear not vulnerable to prompt injection on the first attempt. However, they often reveal vulnerabilities after multiple tries. The iteration count represents the number of attempts, with a default value of 5. You can increase this number as needed.
 
@@ -93,7 +98,7 @@ LLM applications may appear not vulnerable to prompt injection on the first atte
 python promptmap2.py --model llama2 --model-type ollama --iterations 10
 ```
 
-6. Running Specific Rules
+7. Running Specific Rules
 
 You can choose to run specific test rules instead of running all rules. 
 
@@ -102,7 +107,7 @@ You can choose to run specific test rules instead of running all rules.
 python promptmap2.py --model gpt-4 --model-type openai --rules prompt_stealer,distraction_basic
 ```
 
-7. Filtering by Severity Level
+8. Filtering by Severity Level
 
 Each rule in promptmap2 has a severity level (low, medium, or high) indicating its potential impact. You can filter rules based on their severity to focus on specific risk levels.
 

--- a/custom.py
+++ b/custom.py
@@ -1,0 +1,33 @@
+from transformers import pipeline
+
+# Sample custom LLM integration using a lightweight model
+
+def validate_api_keys():
+    """Custom models typically run locally and do not require API keys."""
+    return True
+
+
+def initialize_client(model_name: str):
+    """Initialize a text-generation pipeline."""
+    return pipeline("text-generation", model=model_name)
+
+
+def test_prompt(client, model: str, system_prompt: str, user_prompt: str):
+    """Generate a response using the provided pipeline."""
+    try:
+        prompt = f"{system_prompt}\n{user_prompt}"
+        result = client(prompt, max_new_tokens=100)
+        return result[0]["generated_text"], False
+    except Exception as exc:
+        return f"Error: {exc}", True
+
+
+def validate_model(model_name: str) -> bool:
+    """Check whether the model can be loaded."""
+    try:
+        pipeline("text-generation", model=model_name)
+        return True
+    except Exception as exc:
+        print(f"Error loading model {model_name}: {exc}")
+        return False
+

--- a/promptmap2.py
+++ b/promptmap2.py
@@ -6,6 +6,7 @@ import glob
 import subprocess
 import time
 from typing import Dict, List, Optional
+import importlib
 import openai
 from openai import OpenAI
 import anthropic
@@ -90,8 +91,15 @@ def validate_api_keys(model_type: str):
         raise ValueError("OPENAI_API_KEY environment variable is required for OpenAI models")
     elif model_type == "anthropic" and not os.getenv("ANTHROPIC_API_KEY"):
         raise ValueError("ANTHROPIC_API_KEY environment variable is required for Anthropic models")
+    elif model_type == "custom":
+        try:
+            custom = importlib.import_module("custom")
+            if hasattr(custom, "validate_api_keys"):
+                custom.validate_api_keys()
+        except Exception as e:
+            raise ValueError(f"Custom model API key validation failed: {e}")
 
-def initialize_client(model_type: str):
+def initialize_client(model_type: str, model: str | None = None):
     """Initialize the appropriate client based on the model type."""
     if model_type == "openai":
         return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -101,6 +109,11 @@ def initialize_client(model_type: str):
         if not is_ollama_running():
             if not start_ollama():
                 raise RuntimeError("Failed to start Ollama server")
+        return None
+    elif model_type == "custom":
+        custom = importlib.import_module("custom")
+        if hasattr(custom, "initialize_client"):
+            return custom.initialize_client(model)
         return None
     else:
         raise ValueError(f"Unsupported model type: {model_type}")
@@ -151,7 +164,12 @@ def test_prompt(client, model: str, model_type: str, system_prompt: str, test_pr
                 ]
             )
             return response['message']['content'], False
-            
+        elif model_type == "custom":
+            custom = importlib.import_module("custom")
+            if hasattr(custom, "test_prompt"):
+                return custom.test_prompt(client, model, system_prompt, test_prompt)
+            raise RuntimeError("custom.py must define test_prompt")
+
     except Exception as e:
         return f"Error: {str(e)}", True
 
@@ -349,7 +367,7 @@ def run_tests(model: str, model_type: str, system_prompts_path: str, iterations:
     """Run all tests and return results."""
     print("\nTest started...")
     validate_api_keys(model_type)
-    client = initialize_client(model_type)
+    client = initialize_client(model_type, model)
     system_prompt = load_system_prompts(system_prompts_path)
     results = {}
     
@@ -446,6 +464,16 @@ def validate_model(model: str, model_type: str, auto_yes: bool = False) -> bool:
                 print("Download cancelled")
                 return False
             
+    elif model_type == "custom":
+        try:
+            custom = importlib.import_module("custom")
+            if hasattr(custom, "validate_model"):
+                return custom.validate_model(model)
+            return True
+        except Exception as e:
+            print(f"Error validating custom model: {e}")
+            return False
+
     return True
 
 def show_help():
@@ -462,13 +490,15 @@ Usage Examples:
 3. Test with Ollama:
    python promptmap2.py --model llama2 --model-type ollama
 
-4. Run specific rules:
+4. Test with a custom model:
+   python promptmap2.py --model sshleifer/tiny-gpt2 --model-type custom
+5. Run specific rules:
    python promptmap2.py --model gpt-4 --model-type openai --rules prompt_stealer,distraction_basic
 
-5. Custom options:
+6. Custom options:
    python promptmap2.py --model gpt-4 --model-type openai --iterations 3 --output results_gpt4.json
 
-6. Firewall testing mode:
+7. Firewall testing mode:
    python promptmap2.py --model gpt-4 --model-type openai --firewall --pass-condition="true"
    # In firewall mode, tests pass only if the response contains the specified string
    # and is not more than twice its length
@@ -492,8 +522,8 @@ def main():
     parser = argparse.ArgumentParser(description="Test LLM system prompts against injection attacks")
     parser.add_argument("--prompts", default="system-prompts.txt", help="Path to system prompts file")
     parser.add_argument("--model", required=True, help="LLM model name")
-    parser.add_argument("--model-type", required=True, choices=["openai", "anthropic", "ollama"], 
-                       help="Type of the model (openai, anthropic, ollama)")
+    parser.add_argument("--model-type", required=True, choices=["openai", "anthropic", "ollama", "custom"],
+                       help="Type of the model (openai, anthropic, ollama, custom)")
     parser.add_argument("--severity", type=lambda s: [item.strip() for item in s.split(',')],
                        default=["low", "medium", "high"],
                        help="Comma-separated list of severity levels (low,medium,high). Defaults to all severities.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ollama>=0.1.0
 requests
 tiktoken
 PyYAML
+transformers


### PR DESCRIPTION
## Summary
- add `custom` model type loading custom.py
- provide example custom.py using transformers pipeline
- document custom model usage in README
- include transformers as dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847fc6ca6488332b609fe7f7b059a85